### PR TITLE
Set RUST_TARGET_PATH in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,6 +130,9 @@ ASFLAGS = -m32 -gdwarf-2 -Wa,-divide
 # FreeBSD ld wants ``elf_i386_fbsd''
 LDFLAGS += -m $(shell $(LD) -V | grep elf_i386 2>/dev/null | head -n 1)
 
+# Set Rust target path
+RUST_TARGET_PATH := ${CURDIR}
+
 # Disable PIE when possible (for Ubuntu 16.10 toolchain)
 ifneq ($(shell $(CC) -dumpspecs 2>/dev/null | grep -e '[^f]no-pie'),)
 CFLAGS += -fno-pie -no-pie


### PR DESCRIPTION
This lets the user run `make` without manually specifying a
RUST_TARGET_PATH. This target path is set to the main project directory,
where i386.json lives.