### PR TITLE
Remove unused prototype

### DIFF
--- a/defs.h
+++ b/defs.h
@@ -157,9 +157,6 @@ int             fetchint(uint, int*);
 int             fetchstr(uint, char**);
 void            syscall(void);
 
-// timer.c
-void            timerinit(void);
-
 // trap.c
 void            idtinit(void);
 extern uint     ticks;


### PR DESCRIPTION
I'm not sure why `gcc` doesn't emit a warning about this unused, unimplemented prototype.

Also searched for it's implementation `grep timerinit *` in the code base but nothing showed up. `timer.c` also does not exist.

All tests pass when it's gone, so. ¯\_(ツ)_/¯