### PR TITLE
Add simple integration testing with Travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+sudo: required
+
+language: rust
+rust:
+  - nightly
+
+before_install:
+  - sudo apt update && sudo apt install gcc qemu -y
+  - cargo install cargo-xbuild
+  - rustup component add rust-src
+
+install:
+  - make
+
+script:
+  - ./test.sh

--- a/Makefile
+++ b/Makefile
@@ -186,8 +186,8 @@ rkernel:
 # great for testing the kernel on real hardware without
 # needing a scratch disk.
 MEMFSOBJS = $(filter-out ide.o,$(OBJS)) memide.o
-kernelmemfs: $(MEMFSOBJS) entry.o entryother initcode kernel.ld fs.img
-	$(LD) $(LDFLAGS) -T kernel.ld -o kernelmemfs entry.o  $(MEMFSOBJS) -b binary initcode entryother fs.img
+kernelmemfs: $(MEMFSOBJS) rkernel entry.o entryother initcode kernel.ld fs.img
+	$(LD) $(LDFLAGS) -T kernel.ld -o kernelmemfs entry.o $(MEMFSOBJS) $(RUST_OS) -b binary initcode entryother fs.img
 	$(OBJDUMP) -S kernelmemfs > kernelmemfs.asm
 	$(OBJDUMP) -t kernelmemfs | sed '1,/SYMBOL TABLE/d; s/ .* / /; /^$$/d' > kernelmemfs.sym
 
@@ -290,6 +290,9 @@ qemu: fs.img xv6.img
 
 qemu-memfs: xv6memfs.img
 	$(QEMU) -drive file=xv6memfs.img,index=0,media=disk,format=raw -smp $(CPUS) -m 256
+
+qemu-test-memfs: xv6memfs.img
+	$(QEMU) -display none -serial pipe:vm_fifo -drive file=xv6memfs.img,index=0,media=disk,format=raw -smp $(CPUS) -m 256
 
 qemu-nox: fs.img xv6.img
 	$(QEMU) -nographic $(QEMUOPTS)

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+rm vm_fifo.in vm_fifo.out
+mkfifo vm_fifo.in vm_fifo.out
+
+# Run qemu in the background with no gui and with serial going to vm_fifo.*
+make qemu-test-memfs &
+
+# Read each line of the vm serial output and do stuff
+cat vm_fifo.out | while read i ; do
+    echo "$i"
+
+    # The vm has booted, run usertests
+    if [ "$i" = "init: starting sh" ] ; then
+        echo usertests > vm_fifo.in
+    fi
+
+    # usertests was a success
+    if [ "$i" = "ALL TESTS PASSED" ] ; then
+        echo halt > vm_fifo.in
+        exit 0
+    fi
+
+    # Something failed
+    if [[ "$i" = *"fail"* ]] || [[ "$i" = *"FAIL"* ]] ; then
+        echo halt > vm_fifo.in
+        exit 1
+    fi
+done


### PR DESCRIPTION
I threw this together quickly as sort of a proof of concept of how we could do integration testing. This might be good enough to use for now, but if needed we can iterate on this. i decided to use memfs instead of a proper fs image because that will be faster (travis is slow in general). Down the road it would be good to add unit tests to the travis testing as well.